### PR TITLE
Add !package keyword for new rule targeting (#980)

### DIFF
--- a/edit/edit.go
+++ b/edit/edit.go
@@ -262,6 +262,14 @@ func IndexOfRuleByName(f *build.File, name string) (int, *build.Rule) {
 		if r.Name() == name || start.Line == linenum {
 			return i, r
 		}
+
+		// Allow for precisely targeting the package declaration. This
+		// helps adding new load() and license() rules
+		if name == "!package" {
+			if rule, ok := ExprToRule(stmt, "package"); ok {
+				return i, rule
+			}
+		}
 	}
 	return -1, nil
 }

--- a/edit/edit_test.go
+++ b/edit/edit_test.go
@@ -767,3 +767,41 @@ func TestInterpretLabelForWorkspaceLocation(t *testing.T) {
 	runTestInterpretLabelForWorkspaceLocation(t, "BUILD")
 	runTestInterpretLabelForWorkspaceLocation(t, "BUILD.bazel")
 }
+
+func TestIndexOfRuleByName(t *testing.T) {
+	tests := []struct {
+		query         string
+		expectedIndex int
+	}{
+		{"first", 3},
+		{"%8", 4},
+		{"!package", 2},
+		{"miss", -1},
+	}
+
+	bldText := `"""Docstring."""
+
+load(":path.bzl", "x")
+
+package(default_visibility=":public")
+
+cc_binary(name="first")
+cc_binary(name="second")
+
+`
+	bld, err := build.Parse("BUILD", []byte(bldText))
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	for _, test := range tests {
+		idx, rule := IndexOfRuleByName(bld, test.query)
+		if idx != test.expectedIndex {
+			t.Errorf("TestIndexOfRuleByName(%q) = %d; want %d", test.query, idx, test.expectedIndex)
+			continue
+		}
+		if idx != -1 && rule == nil {
+			t.Errorf("TestIndexOfRuleByName(%q); got nil rule", test.query)
+		}
+	}
+}


### PR DESCRIPTION
* Add !package keyword for new rule targeting

This new keyword helps target placement of new rules near the package()
declaration in a file. This is useful for adding new load() and
license() statements since it keeps them near the top since they are
globally significant rules.

* Restructured the scanning code.

Simplified the code to use the original loop and just check inside that
loop.